### PR TITLE
alloca() requires alloca.h on illumos

### DIFF
--- a/strptime.c
+++ b/strptime.c
@@ -59,6 +59,9 @@
 // #include "libc_private.h"
 #include "timelocal.h"
 // #include "tzfile.h"
+#ifdef __sun
+#include <alloca.h>
+#endif
 
 static char * _strptime(const char *, const char *, struct mytm *, int *, locale_t);
 


### PR DESCRIPTION
One of the C files in the project uses `alloca()`, which is available on illumos (and presumably Solaris) systems through the `alloca.h` header (see [alloca(3C)](https://illumos.org/man/3C/alloca)).  Without this change, the software doesn't quite build correctly:

```
$ go test
# github.com/knz/strtime
strptime.c: In function '_strptime':
strptime.c:591:15: warning: implicit declaration of function 'alloca' [-Wimplicit-function-declaration]
     zonestr = alloca(cp - buf + 1);
               ^~~~~~
strptime.c:591:15: warning: incompatible implicit declaration of built-in function 'alloca'
PASS
ok      github.com/knz/strtime  0.019s
```

With, everything is OK:

```
$ go test
PASS
ok      github.com/knz/strtime  0.022s
```