### PR TITLE
Avoid using alloca()

### DIFF
--- a/strptime.c
+++ b/strptime.c
@@ -582,18 +582,18 @@ label:
 		case 'Z':
 			{
 			const char *cp;
-			char *zonestr;
+			//char *zonestr;
 
 			for (cp = buf; *cp &&
 			     isupper_l((unsigned char)*cp, locale); ++cp) {
 				/*empty*/}
 			if (cp - buf) {
-				zonestr = alloca(cp - buf + 1);
-				strncpy(zonestr, buf, cp - buf);
-				zonestr[cp - buf] = '\0';
+				//zonestr = alloca(cp - buf + 1);
+				//strncpy(zonestr, buf, cp - buf);
+				//zonestr[cp - buf] = '\0';
 				//tzset();
-				if (0 == strcmp(zonestr, "GMT") ||
-				    0 == strcmp(zonestr, "UTC")) {
+				if (0 == strncmp(buf, "GMT", cp - buf) ||
+				    0 == strncmp(buf, "UTC", cp - buf)) {
 				    *GMTp = 1;
 				// } else if (0 == strcmp(zonestr, tzname[0])) {
 				//     tm->tm_isdst = 0;


### PR DESCRIPTION
The alloca() function is not really standard.
It's only supported well on GCC if `alloca.h` is included.
It's only supported without warning on Illumos if `alloca.h` is
included.
*However* `alloca.h` is not available everywhere.

It's better to just not use it whatsoever.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/knz/strtime/4)
<!-- Reviewable:end -->
